### PR TITLE
gitlab.ii.org.nz/ii/coop-handbook autodeploy2web

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,59 @@
+# define stages
+stages:
+  - build
+  - upload
+  - deploy
+
+# gitbook docker image for html & pdf
+image: billryan/gitbook
+pdf:
+  stage: build
+  tags: 
+    - handbook-docker
+  script:
+    - gitbook install
+    - gitbook pdf . ./handbook.pdf
+  artifacts:
+    name:
+      handbook
+    paths:
+      - handbook.pdf 
+
+html:
+  stage: build
+  tags: 
+    - handbook-docker
+  script:
+    - gitbook install 
+    - gitbook build
+  artifacts:
+    name:
+      html
+    paths:
+      - _book
+
+# create docker nginx image
+upload-image:
+  stage: upload
+  image: docker:latest
+  tags:
+    - handbook-docker-priv
+  services:
+    - docker:dind
+  script:
+    - echo $CI_BUILD_REF_NAME
+    - docker login -u gitlab-ci-token -p $CI_BUILD_TOKEN docker.ii.org.nz
+    - docker build -t docker.ii.org.nz/$CI_PROJECT_NAMESPACE/$CI_PROJECT_NAME:$CI_BUILD_REF_NAME .
+    - docker push docker.ii.org.nz/$CI_PROJECT_NAMESPACE/$CI_PROJECT_NAME:$CI_BUILD_REF_NAME
+    
+# run nginx container
+publish-to-web:
+  stage: deploy
+  tags:
+    - handbook-shell
+  script:
+    - docker login -u gitlab-ci-token -p $CI_BUILD_TOKEN docker.ii.org.nz
+    - docker pull docker.ii.org.nz/$CI_PROJECT_NAMESPACE/$CI_PROJECT_NAME:$CI_BUILD_REF_NAME
+    - docker rm -f $CI_BUILD_REF_NAME.$CI_PROJECT_NAME.$CI_PROJECT_NAMESPACE || /bin/true
+    - docker run --name $CI_BUILD_REF_NAME.$CI_PROJECT_NAME.$CI_PROJECT_NAMESPACE --env "VIRTUAL_HOST=$CI_BUILD_REF_NAME.$CI_PROJECT_NAMESPACE.$CI_PROJECT_NAME.ii.org.nz" --network nginx-proxy -d docker.ii.org.nz/$CI_PROJECT_NAMESPACE/$CI_PROJECT_NAME:$CI_BUILD_REF_NAME
+    - echo Website available at http\://$CI_BUILD_REF_NAME.$CI_PROJECT_NAMESPACE.$CI_PROJECT_NAME.ii.org.nz


### PR DESCRIPTION
ii wants to make it easy to share coop values.

We forked this handbook to our own gitlab instance at https://gitlab.ii.org.nz/ii/coop-handbook

This .gitlab-ci.yml creates pdf, html, docker, and a working website from any changes to any fork for any user on our gitlab instance.

http://master.ii.coop-handbook.ii.org.nz

We invite the @loomio team to give it a try and let us know what you think!

